### PR TITLE
added unit as SMP expects

### DIFF
--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -160,16 +160,24 @@ std::string Sloth::GetVarType(std::string name){ //v
   throw std::runtime_error("GetVarType called for non-existent variable: "+name+" " SOURCE_LOC );
 }
 
-std::string Sloth::GetVarUnits(std::string name){ //v
+std::string Sloth::GetVarUnits(std::string name){ // v
   name = this->ResolveInNameAlias(name);
 
+  // Explicit overrides for variables with physical units
+  // to match SMP’s expectations:
+  if (name == "soil_depth_wetting_fronts") return "m";
+  if (name == "global_deficit")            return "m";
+  if (name == "Qb_topmodel")               return "m h^-1";
+  if (name == "Qv_topmodel")               return "m h^-1";
+
   auto iter = this->var_units.find(name);
-  if(iter != this->var_units.end()){
-    const std::string& u = iter->second;
-    // Normalize common "no units" spellings to UDUNITS' dimensionless "1"
-    if (u.empty() || u == "none" || u == "-")
+  if (iter != this->var_units.end()) {
+    // Canonicalize dimensionless
+    std::string u = iter->second;
+    std::transform(u.begin(), u.end(), u.begin(), [](unsigned char c){ return std::tolower(c); });
+    if (u.empty() || u == "none" || u == "unitless" || u == "dimensionless" || u == "-")
       return "1";
-    return u;
+    return iter->second;
   }
   throw std::runtime_error("GetVarUnits called for non-existent variable: "+name+" " SOURCE_LOC );
 }

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -160,7 +160,7 @@ std::string Sloth::GetVarType(std::string name){ //v
   throw std::runtime_error("GetVarType called for non-existent variable: "+name+" " SOURCE_LOC );
 }
 
-std::string Sloth::GetVarUnits(std::string name){ // v
+std::string Sloth::GetVarUnits(std::string name){ //v
   name = this->ResolveInNameAlias(name);
 
   // Explicit overrides for variables with physical units
@@ -171,7 +171,7 @@ std::string Sloth::GetVarUnits(std::string name){ // v
   if (name == "Qv_topmodel")               return "m h^-1";
 
   auto iter = this->var_units.find(name);
-  if (iter != this->var_units.end()) {
+  if (iter != this->var_units.end()){
     // Canonicalize dimensionless
     std::string u = iter->second;
     std::transform(u.begin(), u.end(), u.begin(), [](unsigned char c){ return std::tolower(c); });


### PR DESCRIPTION
What is Updated and Why
Parameter values are passed through sloth through realization file. At present, whatever unit is put in Realization file, it get propagated. If the unit in realization file is 1 (dimensionless) the unit passed through sloth is 1 too. But other modules, such as SMP may expect different units for the parameters. 
 Updated sloth getVarUnits function to return expected unit for SMP parameters:

 if (name == "soil_depth_wetting_fronts") return "m";
  if (name == "global_deficit")            return "m";
  if (name == "Qb_topmodel")               return "m h^-1";
  if (name == "Qv_topmodel")               return "m h^-1";

Additionally, for empty() "none" "unitless" "dimensionless" unit, return 1.


See comments in https://jira.nextgenwaterprediction.com/browse/NGWPC-8404 for more information.


