### PR TITLE
Implement Serialization Messaging (NGWPC-9627)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,15 @@ include_directories(PRIVATE include)
 include_directories(PRIVATE extern/bmi-cxx)
 #target_include_directories(slothmodel PRIVATE ../bmi-cxx/ )
 
+# -----------------------------------------------------------------------------
+# Find the Boost library and configure usage
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.79.0 REQUIRED COMPONENTS serialization)
+
+target_link_libraries(slothmodel PRIVATE Boost::serialization)
+
 set_target_properties(slothmodel PROPERTIES VERSION ${PROJECT_VERSION})
 
 set_target_properties(slothmodel PROPERTIES PUBLIC_HEADER include/sloth.hpp)

--- a/include/sloth.hpp
+++ b/include/sloth.hpp
@@ -6,6 +6,9 @@
 #include <vector>
 #include <map>
 #include "bmi.hxx"
+#include "vecbuf.hpp"
+
+#include <boost/serialization/access.hpp>
 
 #define BMI_TYPE_NAME_DOUBLE "double"
 #define BMI_TYPE_NAME_FLOAT "float"
@@ -83,6 +86,7 @@ class Sloth : public bmi::Bmi {
         void GetGridNodesPerFace(const int grid, int *nodes_per_face) override;
 
     private:
+        friend class boost::serialization::access;
         double current_model_time = 0.0;
 
         std::map<std::string, std::shared_ptr<void>> var_values;
@@ -93,6 +97,8 @@ class Sloth : public bmi::Bmi {
         std::map<std::string, std::string> var_innames;
         // Number of bytes last stored, or (TODO?) <=0 if passed in by pointer (i.e. we don't own the memory).
         std::map<std::string, int> var_nbytes; 
+        vecbuf<char> m_serialized;
+        uint64_t m_serialized_length;
 
         std::map<std::string,int> type_sizes = {
             {BMI_TYPE_NAME_DOUBLE, sizeof(double)},
@@ -130,6 +136,13 @@ class Sloth : public bmi::Bmi {
         std::string ProcessNameMeta(std::string nameMaybeWithMeta);
         void EnsureAllocatedForByValue(std::string name);
 
+        template<class Archive>
+        void serialize(Archive& ar, const unsigned int version);
+        void new_serialized();
+        void load_serialized(const char* data);
+        void free_serialized();
+
+        inline static bool is_serialization_name(const std::string &name);
 };
 
 extern "C"

--- a/include/sloth.hpp
+++ b/include/sloth.hpp
@@ -139,7 +139,7 @@ class Sloth : public bmi::Bmi {
         template<class Archive>
         void serialize(Archive& ar, const unsigned int version);
         void new_serialized();
-        void load_serialized(const char* data);
+        void load_serialized(char* data);
         void free_serialized();
 
         inline static bool is_serialization_name(const std::string &name);

--- a/include/varprops.hpp
+++ b/include/varprops.hpp
@@ -1,0 +1,42 @@
+#include <string>
+#include <memory>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/array.hpp>
+
+struct VariableProps {
+public:
+    VariableProps() = default;
+    ~VariableProps() = default;
+
+    std::string name;
+    std::string units;
+    std::string type;
+    std::string location;
+    std::string inname;
+    int count;
+    int nbytes;
+    std::shared_ptr<void> value;
+
+private:
+    friend class boost::serialization::access;
+
+    template<class Archive>
+    void serialize(Archive& ar, const unsigned int version) {
+        ar & this->name;
+        ar & this->units;
+        ar & this->type;
+        ar & this->location;
+        ar & this->inname;
+        ar & this->count;
+        ar & this->nbytes;
+        if (Archive::is_loading::value) {
+            // if loading, allocate memory for the load size
+            this->value = std::shared_ptr<void>(std::malloc(this->nbytes), std::free);
+        }
+        ar & boost::serialization::make_array(
+            static_cast<char *>(this->value.get()), this->nbytes
+        );
+    }
+
+};

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -1,0 +1,115 @@
+#ifndef HPP_STRING_VECBUF
+#define HPP_STRING_VECBUF
+// https://gist.github.com/stephanlachnit/4a06f8475afd144e73235e2a2584b000
+// SPDX-FileCopyrightText: 2023 Stephan Lachnit
+// SPDX-License-Identifier: MIT
+
+#include <streambuf>
+#include <string>
+#include <vector>
+
+template<class CharT = char, class Traits = std::char_traits<CharT>>
+class vecbuf : public std::basic_streambuf<CharT> {
+public:
+    using streambuf = std::basic_streambuf<CharT, Traits>;
+    using char_type = typename streambuf::char_type;
+    using int_type = typename streambuf::int_type;
+    using traits_type = typename streambuf::traits_type;
+    using vector = std::vector<char_type>;
+    using value_type = typename vector::value_type;
+    using size_type = typename vector::size_type;
+
+    // Constructor for vecbuf with optional initial capacity
+    vecbuf(size_type capacity = 0) : vector_() { reserve(capacity); }
+
+    // Forwarder for std::vector::shrink_to_fit()
+    constexpr void shrink_to_fit() { vector_.shrink_to_fit(); }
+    
+    // Forwarder for std::vector::clear()
+    constexpr void clear() { vector_.clear(); }
+
+    // Forwarder for std::vector::reserve
+    constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
+
+    // Increase the capacity of the buffer by reserving the current_size + additional_capacity
+    constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
+
+    // Forwarder for std::vector::data
+    constexpr const value_type* data() const { return vector_.data(); }
+
+    // Forwarder for std::vector::size
+    constexpr size_type size() const { return vector_.size(); }
+
+    // Forwarder for std::vector::capacity
+    constexpr size_type capacity() const { return vector_.capacity(); }
+
+    // Implements std::basic_streambuf::xsputn
+    std::streamsize xsputn(const char_type* s, std::streamsize count) override {
+        try {
+            reserve_additional(count);
+        }
+        catch (const std::bad_alloc& error) {
+            // reserve did not work, use slow algorithm
+            return xsputn_slow(s, count);
+        }
+        // reserve worked, use fast algorithm
+        return xsputn_fast(s, count);
+    }
+
+protected:
+    // Calculates value to std::basic_streambuf::pbase from vector
+    constexpr value_type* pbase_from_vector() const { return const_cast<value_type*>(vector_.data()); }
+
+    // Calculates value to std::basic_streambuf::pptr from vector
+    constexpr value_type* pptr_from_vector() const { return const_cast<value_type*>(vector_.data() + vector_.size()); }
+
+    // Calculates value to std::basic_streambuf::epptr from vector
+    constexpr value_type* epptr_from_vector() const { return const_cast<value_type*>(vector_.data()) + vector_.capacity(); }
+
+    // Sets the values for std::basic_streambuf::pbase, std::basic_streambuf::pptr and std::basic_streambuf::epptr from vector
+    constexpr void setp_from_vector() { streambuf::setp(pbase_from_vector(), epptr_from_vector()); streambuf::pbump(size()); }
+
+private:
+    // std::vector containing the data
+    vector vector_;
+
+    // Fast implementation of std::basic_streambuf::xsputn if reserve_additional(count) succeeded
+    std::streamsize xsputn_fast(const char_type* s, std::streamsize count) {
+        // store current pptr (end of vector location)
+        auto* old_pptr = pptr_from_vector();
+        // resize the vector, does not move since space already reserved
+        vector_.resize(vector_.size() + count);
+        // directly memcpy new content to old pptr (end of vector before it was resized)
+        traits_type::copy(old_pptr, s, count);
+        // reserve() already calls setp_from_vector(), only adjust pptr to new epptr
+        streambuf::pbump(count);
+
+        return count;
+    }
+
+    // Slow implementation of std::basic_streambuf::xsputn if reserve_additional(count) did not succeed, might calls std::basic_streambuf::overflow()
+    std::streamsize xsputn_slow(const char_type* s, std::streamsize count) {
+        // reserving entire vector failed, emplace char for char
+        std::streamsize written = 0;
+        while (written < count) {
+            try {
+                // copy one char, should throw eventually std::bad_alloc
+                vector_.emplace_back(s[written]);
+            }
+            catch (const std::bad_alloc& error) {
+                // try overflow(), if eof return, else continue
+                int_type c = this->overflow(traits_type::to_int_type(s[written]));
+                if (traits_type::eq_int_type(c, traits_type::eof())) {
+                    return written;
+                }
+            }
+            // update pbase, pptr and epptr
+            setp_from_vector();
+            written++;
+        }
+        return written;
+    }
+
+};
+
+#endif

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -527,7 +527,12 @@ void Sloth::serialize(Archive &ar, const unsigned int version) {
       props.type = this->var_types[value.first];
       props.location = this->var_locations[value.first];
       props.count = this->var_counts[value.first];
-      props.inname = this->var_innames[value.first];
+      auto inname_it = this->var_innames.find(value.first);
+      if (inname_it == this->var_innames.end()) {
+        props.inname = "";
+      } else {
+        props.inname = *inname_it;
+      }
       ar & props;
     }
   }
@@ -547,8 +552,10 @@ void Sloth::serialize(Archive &ar, const unsigned int version) {
       this->var_types[props.name] = props.type;
       this->var_locations[props.name] = props.location;
       this->var_counts[props.name] = props.count;
-      this->var_innames[props.name] = props.inname;
       this->var_nbytes[props.name] = props.nbytes;
+      if (!props.inname.empty()) {
+        this->var_innames[props.name] = props.inname;
+      }
     }
   }
 }

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -359,6 +359,9 @@ std::string Sloth::ProcessNameMeta(std::string name){ //v
   if(this->var_counts.count(name) > 0){
     return name;
   }
+  if (is_serialization_name(name)) {
+    throw std::runtime_error("Attempting to process a name reserved for serialization messaging '" + name + "' " + SOURCE_LOC);
+  }
   // Early-out: if the name passed in is an input alias, will not process metadata, return it.
   if(!this->ResolveInNameAliases(name).empty()){
     return name;
@@ -488,9 +491,7 @@ std::string Sloth::ResolveInNameAlias(std::string name){
 
 std::vector<std::string> Sloth::ResolveInNameAliases(std::string name){
   std::vector<std::string> retval;
-  if (is_serialization_name(name)) {
-    retval.push_back(name);
-  } else {
+  if (!is_serialization_name(name)) {
     for (auto iter = this->var_innames.begin(); iter != this->var_innames.end(); ++iter)
       if (iter->second == name)
         retval.push_back(iter->first);

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -262,7 +262,7 @@ void Sloth::SetValue(std::string name, void* src){ //v
     this->new_serialized();
     return;
   } else if (name == SERIALIZATION_STATE) {
-    this->load_serialized(static_cast<const char*>(src));
+    this->load_serialized(static_cast<char*>(src));
     return;
   } else if (name == SERIALIZATION_FREE) {
     this->free_serialized();
@@ -568,19 +568,26 @@ void Sloth::serialize(Archive &ar, const unsigned int version) {
 }
 
 void Sloth::new_serialized() {
-  this->m_serialized.clear();
+  // remove current data whilst adding space for the final size
+  this->m_serialized.resize(sizeof(uint64_t));
+  // append bytes to store the amount of data archived
   boost::archive::binary_oarchive archive(this->m_serialized);
   try {
     archive << (*this);
     this->m_serialized_length = this->m_serialized.size();
+    // copy size of serialized data minus front size buffer to the beginning of the byte data
+    uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
+    memcpy(this->m_serialized.data(), &serialized_size, sizeof(uint64_t));
   } catch (const std::exception &e) {
     this->m_serialized_length = 0;
     throw;
   }
 }
 
-void Sloth::load_serialized(const char* data) {
-  std::stringstream stream(data);
+void Sloth::load_serialized(char* data) {
+  // grab the size of the data from the beginning of the data stream
+  uint64_t *size = reinterpret_cast<uint64_t *>(data);
+  membuf stream(data + sizeof(uint64_t), *size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -586,8 +586,10 @@ void Sloth::new_serialized() {
 
 void Sloth::load_serialized(char* data) {
   // grab the size of the data from the beginning of the data stream
-  uint64_t *size = reinterpret_cast<uint64_t *>(data);
-  membuf stream(data + sizeof(uint64_t), *size);
+  uint64_t size;
+  memcpy(&size, data, sizeof(uint64_t));
+  // serialized data starts after the size header
+  membuf stream(data + sizeof(uint64_t), size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -532,7 +532,7 @@ void Sloth::serialize(Archive &ar, const unsigned int version) {
       if (inname_it == this->var_innames.end()) {
         props.inname = "";
       } else {
-        props.inname = *inname_it;
+        props.inname = inname_it->second;
       }
       ar & props;
     }

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -4,6 +4,7 @@
 // ^ Credit https://www.decompile.com/cpp/faq/file_and_line_error_string.htm
 
 #include "sloth.hpp"
+#include "varprops.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -13,7 +14,12 @@
 #include <map>
 #include <set>
 #include <limits>
+#include <sstream>
 //#include <iostream>
+
+#include <boost/serialization/serialization.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 
 std::string Sloth::GetComponentName(){
   return "Simple Logical Tautology Handler (SLoTH) Model";
@@ -105,6 +111,14 @@ void Sloth::GetValueAtIndices(std::string name, void* dest, int* inds, int count
 }
 
 void* Sloth::GetValuePtr(std::string name){ //v
+  if (name == "serialization_state") {
+    if (this->m_serialized_length == 0) {
+      throw std::runtime_error("Cannot get the current serialization state before creating one.");
+    }
+    return (void *)this->m_serialized.data();
+  } else if (name == "serialization_size") {
+    return (void *)(&this->m_serialized_length);
+  }
   name = this->ResolveInNameAlias(name);
 
   auto iter = this->var_values.find(name);
@@ -136,6 +150,15 @@ std::string Sloth::GetVarLocation(std::string name){ //v
 }
 
 int Sloth::GetVarNbytes(std::string name){ //v
+  if (name == "serialization_create" || name == "serialization_size") {
+    return sizeof(uint64_t);
+  } else if (name == "serialization_state") {
+    return this->m_serialized_length;
+  } else if (name == "serialization_free") {
+    return sizeof(int);
+  } else if (name == "reset_size") {
+    return sizeof(double);
+  }
   name = this->ProcessNameMeta(name);
   name = this->ResolveInNameAlias(name);
 
@@ -150,6 +173,15 @@ int Sloth::GetVarNbytes(std::string name){ //v
 }
 
 std::string Sloth::GetVarType(std::string name){ //v
+  if (name == "serialization_create" || name == "serialization_size") {
+    return "uint64_t";
+  } else if (name == "serialization_state") {
+    return "char";
+  } else if (name == "serialization_free") {
+    return "int";
+  } else if (name == "reset_size") {
+    return "double";
+  }
   name = this->ProcessNameMeta(name);
   name = this->ResolveInNameAlias(name);
 
@@ -218,6 +250,21 @@ void Sloth::SetValueAtIndices(std::string name, int* inds, int count, void* src)
 }
 
 void Sloth::SetValue(std::string name, void* src){ //v
+  if (name == "serialization_create") {
+    this->new_serialized();
+    return;
+  } else if (name == "serialization_state") {
+    this->load_serialized(static_cast<const char*>(src));
+    return;
+  } else if (name == "serialization_free") {
+    this->free_serialized();
+    return;
+  } else if (name == "reset_time") {
+    this->current_model_time = this->GetStartTime();
+    return;
+  } else if (name == "serialization_size") {
+    throw std::runtime_error("SetValue is not a valid option for \"serialization_size\".");
+  }
   // If this is actually destined for an input alias, punt!...
   auto aliases = this->ResolveInNameAliases(name);
   if(!aliases.empty()){
@@ -427,6 +474,9 @@ std::string Sloth::ProcessNameMeta(std::string name){ //v
 
 std::string Sloth::ResolveInNameAlias(std::string name){
   //TODO: Make a shortcut reverse map for this case?
+  if (is_serialization_name(name)) {
+      return name;
+  }
   std::string retval = name;
   for (auto iter = this->var_innames.begin(); iter != this->var_innames.end(); ++iter)
     if (iter->second == name){
@@ -438,9 +488,13 @@ std::string Sloth::ResolveInNameAlias(std::string name){
 
 std::vector<std::string> Sloth::ResolveInNameAliases(std::string name){
   std::vector<std::string> retval;
-  for (auto iter = this->var_innames.begin(); iter != this->var_innames.end(); ++iter)
-    if (iter->second == name)
-      retval.push_back(iter->first);
+  if (is_serialization_name(name)) {
+    retval.push_back(name);
+  } else {
+    for (auto iter = this->var_innames.begin(); iter != this->var_innames.end(); ++iter)
+      if (iter->second == name)
+        retval.push_back(iter->first);
+  }
   return retval;
 }
 
@@ -452,4 +506,87 @@ void Sloth::EnsureAllocatedForByValue(std::string name){
     nbytes = this->var_nbytes[name] = this->ComputeVarNbytes(name);
     this->var_values.emplace(name, std::shared_ptr<void>(std::malloc(nbytes), std::free));
   }
+}
+
+template<class Archive>
+void Sloth::serialize(Archive &ar, const unsigned int version) {
+  ar & this->current_model_time;
+
+  // store the current number of items
+  int var_size = this->var_values.size();
+  ar & var_size;
+
+  VariableProps props;
+  // if saving, just loop through current values and store them
+  if (Archive::is_saving::value) {
+    for (auto const &value : this->var_values) {
+      props.name = value.first;
+      props.value = value.second;
+      props.nbytes = this->var_nbytes[value.first];
+      props.units = this->var_units[value.first];
+      props.type = this->var_types[value.first];
+      props.location = this->var_locations[value.first];
+      props.count = this->var_counts[value.first];
+      props.inname = this->var_innames[value.first];
+      ar & props;
+    }
+  }
+  // if loading, clear the current data and load as many values as were said to be stored
+  else {
+    this->var_values.clear();
+    this->var_units.clear();
+    this->var_types.clear();
+    this->var_locations.clear();
+    this->var_counts.clear();
+    this->var_innames.clear();
+    this->var_nbytes.clear();
+    while (--var_size >= 0) {
+      ar & props;
+      this->var_values[props.name] = props.value;
+      this->var_units[props.name] = props.units;
+      this->var_types[props.name] = props.type;
+      this->var_locations[props.name] = props.location;
+      this->var_counts[props.name] = props.count;
+      this->var_innames[props.name] = props.inname;
+      this->var_nbytes[props.name] = props.nbytes;
+    }
+  }
+}
+
+void Sloth::new_serialized() {
+  this->m_serialized.clear();
+  boost::archive::binary_oarchive archive(this->m_serialized);
+  try {
+    archive << (*this);
+    this->m_serialized_length = this->m_serialized.size();
+  } catch (const std::exception &e) {
+    this->m_serialized_length = 0;
+    throw;
+  }
+}
+
+void Sloth::load_serialized(const char* data) {
+  std::stringstream stream(data);
+  boost::archive::binary_iarchive archive(stream);
+  try {
+    archive >> (*this);
+  } catch (const std::exception &e) {
+    // possible logging when implemented
+    throw;
+  }
+  this->free_serialized();
+}
+
+void Sloth::free_serialized() {
+  this->m_serialized.clear();
+  this->m_serialized.shrink_to_fit();
+  this->m_serialized_length = 0;
+}
+
+bool Sloth::is_serialization_name(const std::string &name) {
+  return name == "serialization_state"
+    || name == "serialization_size"
+    || name == "serialization_create"
+    || name == "serialization_free"
+    || name == "reset_size";
 }

--- a/src/sloth.cpp
+++ b/src/sloth.cpp
@@ -21,6 +21,14 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 
+namespace {
+  const auto SERIALIZATION_STATE = "serialization_state";
+  const auto SERIALIZATION_CREATE = "serialization_create";
+  const auto SERIALIZATION_SIZE = "serialization_size";
+  const auto SERIALIZATION_FREE = "serialization_free";
+  const auto RESET_TIME = "reset_time";
+}
+
 std::string Sloth::GetComponentName(){
   return "Simple Logical Tautology Handler (SLoTH) Model";
 }
@@ -111,12 +119,12 @@ void Sloth::GetValueAtIndices(std::string name, void* dest, int* inds, int count
 }
 
 void* Sloth::GetValuePtr(std::string name){ //v
-  if (name == "serialization_state") {
+  if (name == SERIALIZATION_STATE) {
     if (this->m_serialized_length == 0) {
       throw std::runtime_error("Cannot get the current serialization state before creating one.");
     }
     return (void *)this->m_serialized.data();
-  } else if (name == "serialization_size") {
+  } else if (name == SERIALIZATION_SIZE) {
     return (void *)(&this->m_serialized_length);
   }
   name = this->ResolveInNameAlias(name);
@@ -150,13 +158,13 @@ std::string Sloth::GetVarLocation(std::string name){ //v
 }
 
 int Sloth::GetVarNbytes(std::string name){ //v
-  if (name == "serialization_create" || name == "serialization_size") {
+  if (name == SERIALIZATION_CREATE || name == SERIALIZATION_SIZE) {
     return sizeof(uint64_t);
-  } else if (name == "serialization_state") {
+  } else if (name == SERIALIZATION_STATE) {
     return this->m_serialized_length;
-  } else if (name == "serialization_free") {
+  } else if (name == SERIALIZATION_FREE) {
     return sizeof(int);
-  } else if (name == "reset_size") {
+  } else if (name == RESET_TIME) {
     return sizeof(double);
   }
   name = this->ProcessNameMeta(name);
@@ -173,13 +181,13 @@ int Sloth::GetVarNbytes(std::string name){ //v
 }
 
 std::string Sloth::GetVarType(std::string name){ //v
-  if (name == "serialization_create" || name == "serialization_size") {
+  if (name == SERIALIZATION_CREATE || name == SERIALIZATION_SIZE) {
     return "uint64_t";
-  } else if (name == "serialization_state") {
+  } else if (name == SERIALIZATION_STATE) {
     return "char";
-  } else if (name == "serialization_free") {
+  } else if (name == SERIALIZATION_FREE) {
     return "int";
-  } else if (name == "reset_size") {
+  } else if (name == RESET_TIME) {
     return "double";
   }
   name = this->ProcessNameMeta(name);
@@ -250,20 +258,18 @@ void Sloth::SetValueAtIndices(std::string name, int* inds, int count, void* src)
 }
 
 void Sloth::SetValue(std::string name, void* src){ //v
-  if (name == "serialization_create") {
+  if (name == SERIALIZATION_CREATE) {
     this->new_serialized();
     return;
-  } else if (name == "serialization_state") {
+  } else if (name == SERIALIZATION_STATE) {
     this->load_serialized(static_cast<const char*>(src));
     return;
-  } else if (name == "serialization_free") {
+  } else if (name == SERIALIZATION_FREE) {
     this->free_serialized();
     return;
-  } else if (name == "reset_time") {
+  } else if (name == RESET_TIME) {
     this->current_model_time = this->GetStartTime();
     return;
-  } else if (name == "serialization_size") {
-    throw std::runtime_error("SetValue is not a valid option for \"serialization_size\".");
   }
   // If this is actually destined for an input alias, punt!...
   auto aliases = this->ResolveInNameAliases(name);
@@ -592,9 +598,9 @@ void Sloth::free_serialized() {
 }
 
 bool Sloth::is_serialization_name(const std::string &name) {
-  return name == "serialization_state"
-    || name == "serialization_size"
-    || name == "serialization_create"
-    || name == "serialization_free"
-    || name == "reset_size";
+  return name == SERIALIZATION_STATE
+    || name == SERIALIZATION_SIZE
+    || name == SERIALIZATION_CREATE
+    || name == SERIALIZATION_FREE
+    || name == RESET_TIME;
 }


### PR DESCRIPTION
To allow for serialization of the BMI data, special variable named used in `GetValuePtr` and `SetValue` correspond to the BMI creating, loading, and destroying serialized byte data that stores current state values that are changed when the BMI's update method is called. Additionally, to facilitate hindcasting, the `SetValue` message "reset_time" will reset the current time of the BMI to zero after loading a state that includes the timestamp.

## Additions

- Messaging signals for creating and loading a state of the SLoTH BMI's current variable values.
- Serialization methods using the Boost library for efficiently creating and loading byte data to SLoTH variables.
- `vecbuff` class used by the Boost serialization methods to store the byte data.
- `VariableProps` struct for aiding in managing variable properties stored in discreate data structures during (de)serialization.
- Requirements for Boost and serialization component in `CMakeLists.txt`

## Removals

-

## Changes

-

## Testing

1. Run on AWS Workspaces demonstrating the ability to save a SLoTH state and reload the values.

## Screenshots


## Notes

- Some comments point to the possibility of letting SLoTH share memory with other BMIs (e.g., SLoTH holds a pointer to the values a CFE BMI owns instead of needing to make a copy each timestep). It appears that this is never used in practice, but implementing something like that in the future would require a much more complicated messaging system between SLoTH and the BMI for storing and loading the current data.
- Whilst SLoTH was theoretically capable of using any name as a variable name, this update breaks that by making the names "serialization_state", "serialization_create", "serialization_free", "serialization_size", and "reset_time" take priority for signaling serialization actions instead of defining or retrieving a new value. However, it's currently unlikely these names will be used for legitimate water model properties, so more complex logic to determine whether the signal is for triggering actions or working with variables is not implemented.
- When using SLoTH with hindcasting, the values defined in the realization config JSON will be replaced with the values stored from the previous run.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
